### PR TITLE
fix issue with mysqli_client_info

### DIFF
--- a/src/Mysqli.php
+++ b/src/Mysqli.php
@@ -17,6 +17,7 @@ use function count;
 use function implode;
 use function ini_get;
 use function microtime;
+use function mysqli_client_info;
 use function mysqli_report;
 use function preg_replace;
 use function str_replace;
@@ -133,7 +134,7 @@ class Mysqli implements DatabaseInterface
             $this->charset = $charset;
             $this->collation = $collation;
 
-            $this->client_info = $this->mysqli->get_client_info();
+            $this->client_info = mysqli_client_info();
             $this->host_info = $this->mysqli->host_info;
             $this->proto_info = (int) $this->mysqli->protocol_version;
             $this->server_info = $this->mysqli->server_info;

--- a/src/Mysqli.php
+++ b/src/Mysqli.php
@@ -17,7 +17,7 @@ use function count;
 use function implode;
 use function ini_get;
 use function microtime;
-use function mysqli_client_info;
+use function mysqli_get_client_info;
 use function mysqli_report;
 use function preg_replace;
 use function str_replace;
@@ -134,7 +134,7 @@ class Mysqli implements DatabaseInterface
             $this->charset = $charset;
             $this->collation = $collation;
 
-            $this->client_info = mysqli_client_info();
+            $this->client_info = mysqli_get_client_info();
             $this->host_info = $this->mysqli->host_info;
             $this->proto_info = (int) $this->mysqli->protocol_version;
             $this->server_info = $this->mysqli->server_info;


### PR DESCRIPTION
replace oop usage of `mysqli->get_client_info` with function `mysqli_get_client_info` as oop usage is deprecated in php 8.1