### PR TITLE
add deprecation notes

### DIFF
--- a/src/MysqliResult.php
+++ b/src/MysqliResult.php
@@ -86,9 +86,15 @@ class MysqliResult implements ResultInterface
      * @copyright       David Lienhard
      * @return          array<string, (int|float|string|bool|null)>
      * @throws          \DavidLienhard\Database\Exception if any mysqli function failed
+     * @deprecated      3.0.0 use fetch_array_assoc() whenever possible
      */
     public function fetch_assoc() : array|null
     {
+        trigger_error(
+            "method MysqliResult\\fetch_assoc() is deprecated as of version 3.0.0",
+            E_USER_DEPRECATED
+        );
+
         return $this->fetch_array_assoc();
     }
 
@@ -121,9 +127,15 @@ class MysqliResult implements ResultInterface
      * @copyright       David Lienhard
      * @return          array<int, (int|float|string|bool|null)>
      * @throws          \DavidLienhard\Database\Exception if any mysqli function failed
+     * @deprecated      3.0.0 use fetch_array_num() whenever possible
      */
     public function fetch_row() : array|null
     {
+        trigger_error(
+            "method MysqliResult\\fetch_row() is deprecated as of version 3.0.0",
+            E_USER_DEPRECATED
+        );
+
         return $this->fetch_array_num();
     }
 

--- a/src/ResultInterface.php
+++ b/src/ResultInterface.php
@@ -42,6 +42,7 @@ interface ResultInterface
      * @author          David Lienhard <github@lienhard.win>
      * @copyright       David Lienhard
      * @return          array<string, (int|float|string|bool|null)>
+     * @deprecated      3.0.0 use fetch_array_assoc() whenever possible
      */
     public function fetch_assoc() : array|null;
 
@@ -61,6 +62,7 @@ interface ResultInterface
      * @author          David Lienhard <github@lienhard.win>
      * @copyright       David Lienhard
      * @return          array<int, (int|float|string|bool|null)>
+     * @deprecated      3.0.0 use fetch_array_num() whenever possible
      */
     public function fetch_row() : array|null;
 

--- a/src/StubResult.php
+++ b/src/StubResult.php
@@ -84,9 +84,15 @@ class StubResult implements ResultInterface
      * @author          David Lienhard <github@lienhard.win>
      * @copyright       David Lienhard
      * @return          array<string, (int|float|string|bool|null)>
+     * @deprecated      3.0.0 use fetch_array_assoc() whenever possible
      */
     public function fetch_assoc() : array|null
     {
+        trigger_error(
+            "method MysqliResult\\fetch_assoc() is deprecated as of version 3.0.0",
+            E_USER_DEPRECATED
+        );
+
         return $this->fetch_array_assoc();
     }
 
@@ -119,9 +125,15 @@ class StubResult implements ResultInterface
      * @author          David Lienhard <github@lienhard.win>
      * @copyright       David Lienhard
      * @return          array<int, (int|float|string|bool|null)>
+     * @deprecated      3.0.0 use fetch_array_num() whenever possible
      */
     public function fetch_row() : array|null
     {
+        trigger_error(
+            "method MysqliResult\\fetch_row() is deprecated as of version 3.0.0",
+            E_USER_DEPRECATED
+        );
+
         return $this->fetch_array_num();
     }
 


### PR DESCRIPTION
add deprecation notes to docblock and print notice for `fetch_assoc()` & `fetch_row()` closes #204